### PR TITLE
Add admin uploads and Google Sheets form

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# eunpyong_club
+# Eunpyeong Club Website
+
+This repository contains a very small static web site for the Eunpyeong club. It includes
+an index page for visitors and a simple admin interface for adding photos or videos of
+club activities.
+
+## Features
+
+- **Gallery**: Uploaded images or videos are saved in the browser's `localStorage` and
+  shown on the main page.
+- **Club Application Form**: Submissions are sent to a Google Sheet using a Google Apps
+  Script web app.
+- **Admin Page**: Accessible via `admin.html` for uploading media and activity text.
+
+## Google Sheets Integration
+
+To make the application form work, deploy a Google Apps Script that writes form data
+into a spreadsheet and replace `YOUR_GOOGLE_APPS_SCRIPT_URL` in `script.js` with the
+web app URL.
+
+## Local Development
+
+Open `index.html` in your browser to view the site. Use `admin.html` to add items to the
+local gallery.

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Admin Upload</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Admin Upload</h1>
+  <form id="uploadForm">
+    <input type="file" id="fileInput" accept="image/*,video/*" required>
+    <textarea id="activityText" placeholder="Activity description" required></textarea>
+    <button type="submit">Upload</button>
+  </form>
+  <p id="uploadMsg"></p>
+  <p><a href="index.html">Back to site</a></p>
+  <script src="admin.js"></script>
+</body>
+</html>

--- a/admin.js
+++ b/admin.js
@@ -1,0 +1,21 @@
+function saveItem(data) {
+  const items = JSON.parse(localStorage.getItem('galleryItems') || '[]');
+  items.push(data);
+  localStorage.setItem('galleryItems', JSON.stringify(items));
+}
+
+document.getElementById('uploadForm').addEventListener('submit', function(e) {
+  e.preventDefault();
+  const fileInput = document.getElementById('fileInput');
+  const text = document.getElementById('activityText').value.trim();
+  const file = fileInput.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = function() {
+    saveItem({ src: reader.result, type: file.type, text: text });
+    document.getElementById('uploadMsg').textContent = 'Uploaded!';
+    fileInput.value = '';
+    document.getElementById('activityText').value = '';
+  };
+  reader.readAsDataURL(file);
+});

--- a/index.html
+++ b/index.html
@@ -8,7 +8,18 @@
 </head>
 <body>
   <h1>Welcome to Eunpyeong Club!</h1>
-  <p>This is your new website. Edit <code>index.html</code> and <code>style.css</code> as you like.</p>
+  <div id="gallery"></div>
+
+  <h2>Club Application</h2>
+  <form id="applicationForm">
+    <input type="text" name="name" placeholder="Name" required>
+    <input type="email" name="email" placeholder="Email" required>
+    <textarea name="message" placeholder="Why do you want to join?" required></textarea>
+    <button type="submit">Submit</button>
+  </form>
+  <p id="formMsg"></p>
+
+  <p><a href="admin.html">Admin page</a></p>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,1 +1,49 @@
-console.log("Welcome to Eunpyeong Club!");
+function loadGallery() {
+  const gallery = document.getElementById('gallery');
+  if (!gallery) return;
+  const items = JSON.parse(localStorage.getItem('galleryItems') || '[]');
+  gallery.innerHTML = '';
+  items.forEach(item => {
+    const wrapper = document.createElement('div');
+    if (item.type.startsWith('image/')) {
+      const img = document.createElement('img');
+      img.src = item.src;
+      img.alt = item.text;
+      wrapper.appendChild(img);
+    } else if (item.type.startsWith('video/')) {
+      const video = document.createElement('video');
+      video.controls = true;
+      video.src = item.src;
+      wrapper.appendChild(video);
+    }
+    const p = document.createElement('p');
+    p.textContent = item.text;
+    wrapper.appendChild(p);
+    gallery.appendChild(wrapper);
+  });
+}
+
+function submitApplication(e) {
+  e.preventDefault();
+  const scriptURL = 'YOUR_GOOGLE_APPS_SCRIPT_URL';
+  const form = e.target;
+  const data = new FormData(form);
+  const msg = document.getElementById('formMsg');
+  fetch(scriptURL, { method: 'POST', body: data })
+    .then(() => {
+      msg.textContent = 'Submitted!';
+      form.reset();
+    })
+    .catch(err => {
+      console.error(err);
+      msg.textContent = 'There was an error.';
+    });
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+  loadGallery();
+  const form = document.getElementById('applicationForm');
+  if (form) {
+    form.addEventListener('submit', submitApplication);
+  }
+});

--- a/style.css
+++ b/style.css
@@ -9,3 +9,27 @@ body {
 h1 {
   color: #176aff;
 }
+
+#gallery div {
+  margin-bottom: 20px;
+}
+
+#gallery img,
+#gallery video {
+  max-width: 200px;
+  display: block;
+  margin-bottom: 5px;
+}
+
+form input,
+form textarea {
+  display: block;
+  margin-bottom: 10px;
+  padding: 8px;
+  width: 100%;
+  max-width: 400px;
+}
+
+form button {
+  padding: 8px 16px;
+}


### PR DESCRIPTION
## Summary
- create admin page for photo/video uploads
- show uploaded items from localStorage on home page
- add club application form with Google Apps Script hook
- document Google Sheets setup in README

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684f5975e7c88324bc7c484f1718718e